### PR TITLE
PR: 항공기 스프라이트를 그릴 때 VBO/VAO, 셰이더 프로그래밍, 인스턴싱을 사용해 GPU와의 통신을 최소화

### DIFF
--- a/DisplayGUI.cpp
+++ b/DisplayGUI.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <filesystem>
 #include <fileapi.h>
+#include <vector>
 
 #pragma hdrstop
 
@@ -91,19 +92,19 @@ uint32_t PopularColors[] = {
  //---------------------------------------------------------------------------
  typedef struct
 {
-   union{ 
-     struct{ 
+   union{
+     struct{
 	 System::Byte Red;
 	 System::Byte Green;
 	 System::Byte Blue;
 	 System::Byte Alpha;
-     }; 
-     struct{ 
-     TColor Cl; 
-     }; 
-     struct{ 
-     COLORREF Rgb; 
-     }; 
+     };
+     struct{
+     TColor Cl;
+     };
+     struct{
+     COLORREF Rgb;
+     };
    };
 
 }TMultiColor;
@@ -270,8 +271,9 @@ void __fastcall TForm1::ObjectDisplayInit(TObject *Sender)
 	MakeAirTrackHostile();
 	MakeAirTrackUnknown();
 	MakePoint();
-	MakeTrackHook();
-	g_EarthView->Resize(ObjectDisplay->Width,ObjectDisplay->Height);
+        MakeTrackHook();
+        InitAirplaneInstancing();
+        g_EarthView->Resize(ObjectDisplay->Width,ObjectDisplay->Height);
 	glPushAttrib (GL_LINE_BIT);
 	glPopAttrib ();
     printf("OpenGL Version %s\n",glGetString(GL_VERSION));
@@ -309,8 +311,15 @@ void __fastcall TForm1::ObjectDisplayPaint(TObject *Sender)
 
  xf=Mw1/Mw2;
  yf=Mh1/Mh2;
-
+ #ifdef MEASURE_PERFORMANCE
+ auto start = std::chrono::steady_clock::now();
+ #endif
  DrawObjects();
+ #ifdef MEASURE_PERFORMANCE
+ auto end = std::chrono::steady_clock::now();
+ auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+ std::cout << "DrawObjects execution time: " << duration << " ms" << std::endl;
+ #endif
 }
 //---------------------------------------------------------------------------
 void __fastcall TForm1::Timer1Timer(TObject *Sender)
@@ -431,26 +440,41 @@ void __fastcall TForm1::DrawObjects(void)
 	 }
 
     AircraftCountLabel->Caption=IntToStr((int)ght_size(HashTable));
-	for(Data = (TADS_B_Aircraft *)ght_first(HashTable, &iterator,(const void **) &Key);
-			  Data; Data = (TADS_B_Aircraft *)ght_next(HashTable, &iterator, (const void **)&Key))
-	{
-	  if (Data->HaveLatLon)
-	  {
-		ViewableAircraft++;
-	   glColor4f(1.0, 1.0, 1.0, 1.0);
+        std::vector<AirplaneInstance> planeBatch;
+        for(Data = (TADS_B_Aircraft *)ght_first(HashTable, &iterator,(const void **) &Key);
+                          Data; Data = (TADS_B_Aircraft *)ght_next(HashTable, &iterator, (const void **)&Key))
+        {
+          if (Data->HaveLatLon)
+          {
+                ViewableAircraft++;
 
-	   LatLon2XY(Data->Latitude,Data->Longitude, ScrX, ScrY);
-	   //DrawPoint(ScrX,ScrY);
-	   if (Data->HaveSpeedAndHeading)   glColor4f(1.0, 0.0, 1.0, 1.0);
-	   else
-		{
-		 Data->Heading=0.0;
-		 glColor4f(1.0, 0.0, 0.0, 1.0);
-		}
+           LatLon2XY(Data->Latitude,Data->Longitude, ScrX, ScrY);
+           //DrawPoint(ScrX,ScrY);
+           float color[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+           if (Data->HaveSpeedAndHeading)
+           {
+                 color[0]=1.0f; color[1]=0.0f; color[2]=1.0f; color[3]=1.0f;
+           }
+           else
+                {
+                 Data->Heading=0.0;
+                 color[0]=1.0f; color[1]=0.0f; color[2]=0.0f; color[3]=1.0f;
+                }
 
-	   DrawAirplaneImage(ScrX,ScrY,1.5,Data->Heading,Data->SpriteImage);
-	   glRasterPos2i(ScrX+30,ScrY-10);
-	   ObjectDisplay->Draw2DText(Data->HexAddr);
+           AirplaneInstance inst;
+           inst.x=ScrX;
+           inst.y=ScrY;
+           inst.scale=1.5f;
+           inst.heading=Data->Heading;
+           inst.imageNum=Data->SpriteImage;
+           inst.color[0]=color[0];
+           inst.color[1]=color[1];
+           inst.color[2]=color[2];
+           inst.color[3]=color[3];
+           planeBatch.push_back(inst);
+
+           glRasterPos2i(ScrX+30,ScrY-10);
+           ObjectDisplay->Draw2DText(Data->HexAddr);
 
 	   if ((Data->HaveSpeedAndHeading) && (TimeToGoCheckBox->State==cbChecked))
 	   {
@@ -467,8 +491,9 @@ void __fastcall TForm1::DrawObjects(void)
 			 glEnd();
 		  }
 	   }
-	 }
-	}
+        }
+       }
+        DrawAirplaneImagesInstanced(planeBatch);
  ViewableAircraftCountLabel->Caption=ViewableAircraft;
  if (TrackHook.Valid_CC)
  {
@@ -1073,7 +1098,7 @@ void __fastcall TForm1::FormMouseWheel(TObject *Sender, TShiftState Shift,
 	  g_EarthView->SingleMovement(NAV_ZOOM_IN);
  else g_EarthView->SingleMovement(NAV_ZOOM_OUT);
   ObjectDisplay->Repaint();
-}                                  
+}
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 void __fastcall TTCPClientRawHandleThread::HandleInput(void)
@@ -1588,8 +1613,8 @@ void __fastcall TForm1::LoadMap(int Type)
 
     // 2. 캐시 디렉터리는  생성
     std::string cachedir = provider->GetCacheDir();
-    if (mkdir(cachedir.c_str()) != 0 && errno != EEXIST)
-        throw Sysutils::Exception("Can not create cache directory");
+     if (mkdir(cachedir.c_str()) != 0 && errno != EEXIST)
+	    throw Sysutils::Exception("Can not create cache directory");
 
     // 3. FilesystemStorage 생성 및 TileManager, Layer, View 연결
     //    (provider가 storage를 직접 관리하지 않고, 외부에서 생성/공유)
@@ -2045,4 +2070,5 @@ static int FinshARTCCBoundary(void)
  return 0 ;
 }
 //---------------------------------------------------------------------------
+
 

--- a/ntds2d.cpp
+++ b/ntds2d.cpp
@@ -4,6 +4,8 @@
 #include <windows.h>
 #include <gl\gl.h>
 #include <gl\glu.h>
+#include <gl\glext.h>
+#include <vector>
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -32,12 +34,100 @@ static GLuint SURFACE_TRACK_FRIEND ;
 static GLuint TRACKHOOK;
 
 static GLuint TextureSpites[NUM_SPRITES];
+static GLuint TextureSpriteArray = 0;
 static int NumSprites=0;
+
+struct InstancingResources {
+    bool initialized;
+    GLuint vao;
+    GLuint quadVBO;
+    GLuint instanceVBO;
+    GLuint program;
+};
+
+static InstancingResources gInstancing = {false};
+
+// OpenGL extension function pointers for systems with only GL 1.1 headers
+static bool gExtensionsLoaded = false;
+static PFNGLCREATESHADERPROC           pglCreateShader           = nullptr;
+static PFNGLSHADERSOURCEPROC           pglShaderSource           = nullptr;
+static PFNGLCOMPILESHADERPROC          pglCompileShader          = nullptr;
+static PFNGLCREATEPROGRAMPROC          pglCreateProgram          = nullptr;
+static PFNGLATTACHSHADERPROC           pglAttachShader           = nullptr;
+static PFNGLLINKPROGRAMPROC            pglLinkProgram            = nullptr;
+static PFNGLDELETESHADERPROC           pglDeleteShader           = nullptr;
+static PFNGLUSEPROGRAMPROC             pglUseProgram             = nullptr;
+static PFNGLACTIVETEXTUREPROC          pglActiveTexture          = nullptr;
+static PFNGLGETUNIFORMLOCATIONPROC     pglGetUniformLocation     = nullptr;
+static PFNGLUNIFORM1IPROC              pglUniform1i              = nullptr;
+static PFNGLUNIFORM2FPROC              pglUniform2f              = nullptr;
+static PFNGLGENVERTEXARRAYSPROC        pglGenVertexArrays        = nullptr;
+static PFNGLBINDVERTEXARRAYPROC        pglBindVertexArray        = nullptr;
+static PFNGLGENBUFFERSPROC             pglGenBuffers             = nullptr;
+static PFNGLBINDBUFFERPROC             pglBindBuffer             = nullptr;
+static PFNGLBUFFERDATAPROC             pglBufferData             = nullptr;
+static PFNGLENABLEVERTEXATTRIBARRAYPROC pglEnableVertexAttribArray = nullptr;
+static PFNGLVERTEXATTRIBPOINTERPROC    pglVertexAttribPointer    = nullptr;
+static PFNGLVERTEXATTRIBDIVISORPROC    pglVertexAttribDivisor    = nullptr;
+static PFNGLVERTEXATTRIBIPOINTERPROC   pglVertexAttribIPointer   = nullptr;
+static PFNGLDRAWARRAYSINSTANCEDPROC    pglDrawArraysInstanced    = nullptr;
+static PFNGLTEXIMAGE3DPROC             pglTexImage3D             = nullptr;
+static PFNGLTEXSUBIMAGE3DPROC          pglTexSubImage3D          = nullptr;
+
+
+static void *GetAnyGLFuncAddress(const char *name)
+{
+#ifdef _WIN32
+    void *p = (void*)wglGetProcAddress(name);
+    if(!p)
+    {
+        static HMODULE ogl = GetModuleHandleA("opengl32.dll");
+        if(ogl) p = (void*)GetProcAddress(ogl, name);
+    }
+    return p;
+#else
+    return (void*)glXGetProcAddressARB((const GLubyte*)name);
+#endif
+}
+
+static void LoadGLExtensions()
+{
+    if (gExtensionsLoaded) return;
+#define LOAD_PROC(type, name) name = (type)GetAnyGLFuncAddress(#name + 1);
+
+    LOAD_PROC(PFNGLTEXIMAGE3DPROC, pglTexImage3D);
+    LOAD_PROC(PFNGLTEXSUBIMAGE3DPROC, pglTexSubImage3D);
+    LOAD_PROC(PFNGLCREATESHADERPROC, pglCreateShader);
+    LOAD_PROC(PFNGLSHADERSOURCEPROC, pglShaderSource);
+    LOAD_PROC(PFNGLCOMPILESHADERPROC, pglCompileShader);
+    LOAD_PROC(PFNGLCREATEPROGRAMPROC, pglCreateProgram);
+    LOAD_PROC(PFNGLATTACHSHADERPROC, pglAttachShader);
+    LOAD_PROC(PFNGLLINKPROGRAMPROC, pglLinkProgram);
+    LOAD_PROC(PFNGLDELETESHADERPROC, pglDeleteShader);
+    LOAD_PROC(PFNGLUSEPROGRAMPROC, pglUseProgram);
+    LOAD_PROC(PFNGLACTIVETEXTUREPROC, pglActiveTexture);
+    LOAD_PROC(PFNGLGETUNIFORMLOCATIONPROC, pglGetUniformLocation);
+    LOAD_PROC(PFNGLUNIFORM1IPROC, pglUniform1i);
+    LOAD_PROC(PFNGLUNIFORM2FPROC, pglUniform2f);
+    LOAD_PROC(PFNGLGENVERTEXARRAYSPROC, pglGenVertexArrays);
+    LOAD_PROC(PFNGLBINDVERTEXARRAYPROC, pglBindVertexArray);
+    LOAD_PROC(PFNGLGENBUFFERSPROC, pglGenBuffers);
+    LOAD_PROC(PFNGLBINDBUFFERPROC, pglBindBuffer);
+    LOAD_PROC(PFNGLBUFFERDATAPROC, pglBufferData);
+    LOAD_PROC(PFNGLENABLEVERTEXATTRIBARRAYPROC, pglEnableVertexAttribArray);
+    LOAD_PROC(PFNGLVERTEXATTRIBPOINTERPROC, pglVertexAttribPointer);
+    LOAD_PROC(PFNGLVERTEXATTRIBDIVISORPROC, pglVertexAttribDivisor);
+    LOAD_PROC(PFNGLVERTEXATTRIBIPOINTERPROC, pglVertexAttribIPointer);
+    LOAD_PROC(PFNGLDRAWARRAYSINSTANCEDPROC, pglDrawArraysInstanced);
+    #undef LOAD_PROC
+    gExtensionsLoaded = true;
+}
 
 
 //---------------------------------------------------------------------------
 int MakeAirplaneImages(void)
 {
+    LoadGLExtensions();
 	bool hasAlpha=false;
 	const char filename[] = "..\\..\\Symbols\\sprites-RGBA.png";
 
@@ -61,7 +151,17 @@ int MakeAirplaneImages(void)
 	if (nrChannels==4) {
      hasAlpha=true;
 	}
-	glGenTextures(NUM_SPRITES, TextureSpites);
+        glGenTextures(NUM_SPRITES, TextureSpites);
+        glGenTextures(1, &TextureSpriteArray);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, TextureSpriteArray);
+        pglTexImage3D(GL_TEXTURE_2D_ARRAY, 0, hasAlpha ? GL_RGBA : GL_RGB,
+                     SPRITE_WIDTH, SPRITE_HEIGHT, NUM_SPRITES, 0,
+                     hasAlpha ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, NULL);
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
 	for (int row = 0; row < 11; row++)
 	{
 	 for (int col = 0; col < 8; col++)
@@ -78,11 +178,18 @@ int MakeAirplaneImages(void)
            }
          }
 
-	  glBindTexture(GL_TEXTURE_2D, TextureSpites[NumSprites]);
-	  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	  glTexImage2D(GL_TEXTURE_2D, 0, hasAlpha ? 4 : 3, SPRITE_WIDTH,
-				 SPRITE_HEIGHT, 0, hasAlpha ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE,
-				 SpriteTexture);
+        glBindTexture(GL_TEXTURE_2D, TextureSpites[NumSprites]);
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+        glTexImage2D(GL_TEXTURE_2D, 0, hasAlpha ? 4 : 3, SPRITE_WIDTH,
+                                   SPRITE_HEIGHT, 0, hasAlpha ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE,
+                                   SpriteTexture);
+
+        glBindTexture(GL_TEXTURE_2D_ARRAY, TextureSpriteArray);
+        pglTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, 0, 0, NumSprites,
+                        SPRITE_WIDTH, SPRITE_HEIGHT, 1,
+                        hasAlpha ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE,
+                        SpriteTexture);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
 
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -241,8 +348,8 @@ void MakeTrackHook(void)
  glEndList();
 }
  //---------------------------------------------------------------------------
- void DrawAirplaneImage(float x, float y,float scale,float heading,int imageNum)
- {
+void DrawAirplaneImage(float x, float y,float scale,float heading,int imageNum)
+{
    glPushMatrix();
    glEnable(GL_TEXTURE_2D);
    glBindTexture(GL_TEXTURE_2D, TextureSpites[imageNum]);
@@ -266,8 +373,141 @@ void MakeTrackHook(void)
    glEnd();
    glBindTexture(GL_TEXTURE_2D, 0);
    glDisable(GL_TEXTURE_2D);
-   glPopMatrix();
- }
+  glPopMatrix();
+}
+
+static GLuint CompileShader(GLenum type, const char* src)
+{
+    GLuint sh = pglCreateShader(type);
+    pglShaderSource(sh, 1, &src, NULL);
+    pglCompileShader(sh);
+    return sh;
+}
+
+static GLuint CreateProgram(const char* vs, const char* fs)
+{
+    GLuint v = CompileShader(GL_VERTEX_SHADER, vs);
+    GLuint f = CompileShader(GL_FRAGMENT_SHADER, fs);
+    GLuint p = pglCreateProgram();
+    pglAttachShader(p, v);
+    pglAttachShader(p, f);
+    pglLinkProgram(p);
+    pglDeleteShader(v);
+    pglDeleteShader(f);
+    return p;
+}
+
+void InitAirplaneInstancing()
+{
+    LoadGLExtensions();
+    if(gInstancing.initialized) return;
+
+    const char* vsSrc =
+        "#version 330 core\n"
+        "layout(location=0) in vec2 vert;\n"
+        "layout(location=1) in vec2 uv;\n"
+        "layout(location=2) in vec2 pos;\n"
+        "layout(location=3) in float scale;\n"
+        "layout(location=4) in float heading;\n"
+        "layout(location=5) in int image;\n"
+        "layout(location=6) in vec4 color;\n"
+        "uniform vec2 Viewport;\n"
+        "out vec2 Tex;\n"
+        "out vec4 Color;\n"
+        "flat out int Image;\n"
+        "void main(){\n"
+        "  float rad = radians(-heading - 90.0);\n"
+        "  mat2 R = mat2(cos(rad), sin(rad), -sin(rad), cos(rad));\n"
+        "  vec2 p = pos + R * (vert * scale * 36.0);\n"
+        "  vec2 ndc = vec2((p.x / Viewport.x) * 2.0 - 1.0, (p.y / Viewport.y) * 2.0 - 1.0);\n"
+        "  gl_Position = vec4(ndc, 0.0, 1.0);\n"
+        "  Tex = uv;\n"
+        "  Color = color;\n"
+        "  Image = image;\n"
+        "}\n";
+
+    const char* fsSrc =
+        "#version 330 core\n"
+        "in vec2 Tex;\n"
+        "in vec4 Color;\n"
+        "flat in int Image;\n"
+        "out vec4 Frag;\n"
+        "uniform sampler2DArray spriteTex;\n"
+        "void main(){\n"
+        "  Frag = texture(spriteTex, vec3(Tex, Image)) * Color;\n"
+        "}\n";
+
+    gInstancing.program = CreateProgram(vsSrc, fsSrc);
+
+    float quad[] = {
+        1.0f, 1.0f, 1.0f, 1.0f,
+       -1.0f, 1.0f, 0.0f, 1.0f,
+       -1.0f,-1.0f, 0.0f, 0.0f,
+        1.0f,-1.0f, 1.0f, 0.0f
+    };
+
+    pglGenVertexArrays(1, &gInstancing.vao);
+    pglBindVertexArray(gInstancing.vao);
+
+    pglGenBuffers(1, &gInstancing.quadVBO);
+    pglBindBuffer(GL_ARRAY_BUFFER, gInstancing.quadVBO);
+    pglBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
+    pglEnableVertexAttribArray(0);
+    pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4*sizeof(float), (void*)0);
+    pglEnableVertexAttribArray(1);
+    pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4*sizeof(float), (void*)(2*sizeof(float)));
+
+    pglGenBuffers(1, &gInstancing.instanceVBO);
+    pglBindBuffer(GL_ARRAY_BUFFER, gInstancing.instanceVBO);
+    pglBufferData(GL_ARRAY_BUFFER, 0, NULL, GL_STREAM_DRAW);
+
+    size_t stride = sizeof(AirplaneInstance);
+    pglEnableVertexAttribArray(2);
+    pglVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, (void*)offsetof(AirplaneInstance, x));
+    pglVertexAttribDivisor(2,1);
+    pglEnableVertexAttribArray(3);
+    pglVertexAttribPointer(3, 1, GL_FLOAT, GL_FALSE, stride, (void*)offsetof(AirplaneInstance, scale));
+    pglVertexAttribDivisor(3,1);
+    pglEnableVertexAttribArray(4);
+    pglVertexAttribPointer(4, 1, GL_FLOAT, GL_FALSE, stride, (void*)offsetof(AirplaneInstance, heading));
+    pglVertexAttribDivisor(4,1);
+    pglEnableVertexAttribArray(5);
+    pglVertexAttribIPointer(5, 1, GL_INT, stride, (void*)offsetof(AirplaneInstance, imageNum));
+    pglVertexAttribDivisor(5,1);
+    pglEnableVertexAttribArray(6);
+    pglVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, stride, (void*)offsetof(AirplaneInstance, color));
+    pglVertexAttribDivisor(6,1);
+
+    pglBindBuffer(GL_ARRAY_BUFFER, 0);
+    pglBindVertexArray(0);
+
+    gInstancing.initialized = true;
+}
+
+void DrawAirplaneImagesInstanced(const std::vector<AirplaneInstance>& instances)
+{
+    if(instances.empty()) return;
+    if(!gInstancing.initialized)
+        InitAirplaneInstancing();
+
+    pglBindVertexArray(gInstancing.vao);
+    pglBindBuffer(GL_ARRAY_BUFFER, gInstancing.instanceVBO);
+    pglBufferData(GL_ARRAY_BUFFER, instances.size()*sizeof(AirplaneInstance), instances.data(), GL_STREAM_DRAW);
+
+    pglUseProgram(gInstancing.program);
+    GLint vp[4];
+    glGetIntegerv(GL_VIEWPORT, vp);
+    pglUniform2f(pglGetUniformLocation(gInstancing.program, "Viewport"), (float)vp[2], (float)vp[3]);
+    pglActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, TextureSpriteArray);
+    pglUniform1i(pglGetUniformLocation(gInstancing.program, "spriteTex"), 0);
+
+    pglDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, instances.size());
+
+    glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+    pglBindVertexArray(0);
+    pglUseProgram(0);
+}
 //---------------------------------------------------------------------------
 void DrawAirTrackFriend(float x, float y)
  {
@@ -354,7 +594,7 @@ void DrawAirTrackUnknown(float x, float y)
 }
  #if 0
 //---------------------------------------------------------------------------
-// SAVE ORIGINAL CODE   ** DO NOT DELETE 
+// SAVE ORIGINAL CODE   ** DO NOT DELETE
 //
   void DrawCovarianceEllipse(float c[][2], float cx,float cy, float sf)
   {
@@ -382,7 +622,7 @@ void DrawAirTrackUnknown(float x, float y)
    _DrawEllipse(theta, major*3, minor*3,cx,cy,sf );
  }
 //---------------------------------------------------------------------------
-// SAVE ORIGINAL CODE   ** DO NOT DELETE 
+// SAVE ORIGINAL CODE   ** DO NOT DELETE
 //
  //---------------------------------------------------------------------------
  void _DrawEllipse(float major_deg, float major_len, float minor_len, float cx,
@@ -420,9 +660,10 @@ int i;
 }
  //---------------------------------------------------------------------------
 #endif
- 
 
 
 
- 
+
+
+
 

--- a/ntds2d.h
+++ b/ntds2d.h
@@ -2,6 +2,7 @@
 
 #ifndef NTDS2DH
 #define NTDS2DH
+#include <vector>
 int MakeAirplaneImages(void);
 void MakeAirTrackFriend(void);
 void MakeAirTrackHostile(void);
@@ -13,6 +14,16 @@ void DrawAirTrackHostile(float x,float y);
 void DrawAirTrackUnknown(float x,float y);
 void DrawPoint(float x,float y);
 void DrawAirplaneImage(float x, float y,float scale,float heading,int imageNum);
+struct AirplaneInstance {
+    float x;
+    float y;
+    float scale;
+    float heading;
+    int   imageNum;
+    float color[4];
+};
+void InitAirplaneInstancing();
+void DrawAirplaneImagesInstanced(const std::vector<AirplaneInstance>& instances);
 void DrawTrackHook(float x, float y);
 void DrawRadarCoverage(float xc, float yc, float major, float minor);
 void DrawLeader(float x1, float y1, float x2, float y2);
@@ -20,8 +31,9 @@ void ComputeTimeToGoPosition(float  TimeToGo,
 							 float  xs, float  ys,
 							 float  xv, float  yv,
 							 float &xe, float &ye);
- void DrawLines(DWORD resolution, double xpts[],double ypts[]);				   
+ void DrawLines(DWORD resolution, double xpts[],double ypts[]);
 
 //---------------------------------------------------------------------------
 #endif
+
 


### PR DESCRIPTION
안녕하세요.

성능 향상을 위해 Sprite 렌더링에서 연산 오버헤드를 줄인 PR입니다.

주요 변경 사항은 다음과 같습니다.

1. DrawAirplaneImage 호출 최소화

- 기존에는 비행기 개수만큼 DrawAirplaneImage를 호출하여 GPU와 N번 통신하였습니다.
- 변경 후에는 모든 비행기 정보를 std::vector에 모아 OpenGL VBO로 한 번에 전달하고, DrawAirplaneImagesInstanced에서 GPU가 VBO의 비행기 정보를 갱신하도록 하여 GPU와의 통신을 1회로 줄였습니다.

2. CPU 연산 일부를 GPU로 이전

- 셰이더 프로그래밍을 적용하여, 기존에 CPU에서 처리하던 일부 연산을 GPU에서 수행하도록 개선하였습니다.